### PR TITLE
Check we can produce a release build too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+      - name: Build (release)
+        run: cargo build --release --verbose
+
       - name: Run clippy
         run: cargo clippy -- -D warnings
 


### PR DESCRIPTION
Recently several release profile options were added to reduce executable size. Let's check that these do not break anything on all platforms.